### PR TITLE
Fix: Link to Sub Contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 ## ツール
 **OS/言語を問わず利用するツールの情報**
 - [Visual Studio Code 1.87.2](https://code.visualstudio.com/) <span style="color: red;">*<<2024/03/13 updated from 1.87.1>>*</span> <BR />
-  開発環境はVisual Studio Codeを中心に使っており、インストールしている拡張機能の一覧は、[VSCode拡張機能](_sub/vscodeExtensions.md)にまとめてあります。<BR />
+  開発環境はVisual Studio Codeを中心に使っており、インストールしている拡張機能の一覧は、[VSCode拡張機能](./_sub/vscodeExtensions.md)にまとめてあります。<BR />
   - 1.82で発生していたデバッグコンソールがクリアできなくなった問題は、1.82.2で解消
 - [Git 2.44](https://git-scm.com/download) <span style="color: red;">*<<2024/03/10 updated from 2.43>>*</span>
 - [GitHub Desktop 3.3.11](https://desktop.github.com/release-notes/) <span style="color: red;">*<<2024/03/10 updated from 3.3.8>>*</span>


### PR DESCRIPTION
- 【現象】GitHub外でVSCodeの拡張機能一覧へのリンクをクリックすると、404エラーとなっていた
- 【原因】VSCodeの拡張機能一覧に対するリンクが絶対パスになっていたため
- 【対策】VSCodeの拡張機能一覧に対するリンクを相対パスに修正