### PR TITLE
Fix: about Windows Insider Build 26090

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,8 @@
 **独学環境の情報**
 - [Windows Insider](https://aka.ms/DevLatest)
   - Dev Channel for Windows 11 24H2 (Build 26xxx)
-    - Build 26090 <span style="color: red;">*<<2024/03/29 updated from 26085>>*</span><br>
-      **右下のバージョン情報はない（今後復活する）**
-      代替手段として、"システム/バージョン情報"をキャプチャ
+    - Build 26090 <span style="color: red;">*<<2024/03/29 updated from 26085>>*</span>
+      - 右下のバージョン情報はない（今後復活する）ため、代わりに「システム > バージョン情報」で確認
       ![デスクトップ](./images/Windows/20240329_Windows11_Build26090.png)
     - [履歴](./history/Windows.md)
 - [WSL2](https://learn.microsoft.com/ja-jp/windows/wsl/install)


### PR DESCRIPTION
Build 26090にてバージョン情報が壁紙のすかしに入らないため、バージョンをシステム＞バージョン情報にてを確認している説明を見直し