### PR TITLE
Update: Bun 1.1.0 on WSL2 and Windows

### DIFF
--- a/knowhow/Rust.md
+++ b/knowhow/Rust.md
@@ -13,6 +13,7 @@
       |Mini-S12   |[Rust 1.77.1](#rust-1)                         |[2024/03/30](https://www.rust-lang.org/)  
       |           |[RustRover 2023.3 EAP Build 13](#rustrover)    |[2024/03/30](https://www.jetbrains.com/rust/)
       |           |[Tauri 2.0.0-beta.13](#tauridesktop-framework) |[2024/03/27](https://beta.tauri.app/)
+      |           |Bun 1.1.0                                      |[2024/04/03](https://bun.sh/)
       |           |[Bevy 0.13](#game-engine)                      |[2024/03/15](https://bevyengine.org/)
 
   1. Ubuntu 22.04.4 on Windows 11
@@ -21,8 +22,8 @@
       |Mini-S12   |Rust 1.77.0  |2024/03/27
       |           |Tauri 1.6.1  |2024/03/27
       |           |React 18.2.38|2023/11/24
-      |           |Vite 5.2.6   |2024/03/27
-      |           |Bun 1.0.35   |2024/03/27
+      |           |Vite 5.2.7   |2024/04/03
+      |           |Bun 1.1.0    |[2024/04/03](https://bun.sh/)
       |           |Bevy 0.10.1  |2023/04/30
 
   1. Chrome OS Flex 122.0.6261.137(Official Build)

--- a/knowhow/TypeScript.md
+++ b/knowhow/TypeScript.md
@@ -34,11 +34,11 @@
       |           |React Native 0.73.1 |[2024/01/07](https://reactnative.dev/)
       |           |- for Windows 0.73.2|2024/01/07
 
-  1. Ubuntu 22.04.3 on Windows 11
+  1. Ubuntu 22.04.4 on Windows 11
       |端末       |環境／FW             |最終更新
       |-----------|--------------------|----------
-      |IdeaPad    |Astro 4.5.5         |[2024/03/16](https://astro.build/)
-      |           |Bun 1.0.31          |[2024/03/16](https://bun.sh/)
+      |IdeaPad    |Astro 4.5.14        |[2024/04/03](https://astro.build/)
+      |           |Bun 1.1.0           |[2024/04/03](https://bun.sh/)
       |           |React 18.2.0        |2024/01/03
       |Mini-S12   |Bun 1.0.19          |2023/12/23
 

--- a/knowhow/TypeScript.md
+++ b/knowhow/TypeScript.md
@@ -84,13 +84,18 @@
 ### Runtime/ORM
   - [Bun](https://bun.sh/)
     - Install
-      ```sh
-      curl -fsSL https://bun.sh/install | bash
-      ```
-      - unzip is required to install bun (see: https://github.com/oven-sh/bun#unzip-is-required)
-        ```sh
-        sudo apt install unzip
+      - Windows
         ```
+        powershell -c "irm bun.sh/install.ps1 | iex"
+        ```
+      - WSL2
+        ```sh
+        curl -fsSL https://bun.sh/install | bash
+        ```
+        - unzip is required to install bun (see: https://github.com/oven-sh/bun#unzip-is-required)
+          ```sh
+          sudo apt install unzip
+          ```
     - Run
       ```sh
       bun run


### PR DESCRIPTION
Bunを1.1.0に更新する
- WSL環境にて、Bunを1.1.0に更新する
  - Tauri 1.6.1で動作確認
  - Astro 4.5.14で動作確認
- Windows環境にて、Bun 1.1.0をインストール
  - Tauri 2.0 betaで動作確認
