### PR TITLE
Update: Git 2.45 and GitHub Desktop 3.3.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@
 - [Visual Studio Code 1.88.1](https://code.visualstudio.com/) <span style="color: red;">*<<2024/04/12 updated from 1.88>>*</span> <BR />
   開発環境はVisual Studio Codeを中心に使っており、インストールしている拡張機能の一覧は、[VSCode拡張機能](./sub/vscodeExtensions.md)にまとめてあります。<BR />
   - 1.82で発生していたデバッグコンソールがクリアできなくなった問題は、1.82.2で解消
-- [Git 2.44](https://git-scm.com/download) <span style="color: red;">*<<2024/03/10 updated from 2.43>>*</span>
-- [GitHub Desktop 3.3.11](https://desktop.github.com/release-notes/) <span style="color: red;">*<<2024/03/10 updated from 3.3.8>>*</span>
+- [Git 2.45](https://git-scm.com/download) <span style="color: red;">*<<2024/05/01 updated from 2.44>>*</span>
+- [GitHub Desktop 3.3.14](https://desktop.github.com/release-notes/) <span style="color: red;">*<<2024/05/01 updated from 3.3.11>>*</span>
   - サイトでのリリース通知があってから、アップデートできるまでにはタイムラグがありそう
-- PowerShell 7.4.2
+- [PowerShell 7.4.2](https://github.com/PowerShell/PowerShell)
 - [Docker](./knowhow/Docker.md)
 
 ##  サービス

--- a/knowhow/Rust.md
+++ b/knowhow/Rust.md
@@ -20,7 +20,7 @@
       |           |[RustRover 2024.1 EAP](#rustrover)             |[2024/04/25](https://www.jetbrains.com/rust/)
       |           |[Tauri 2.0.0-beta.15](#tauridesktop-framework) |[2024/04/19](https://beta.tauri.app/)
       |           |Bun 1.1.5                                      |[2024/04/26](https://bun.sh/)
-      |           |[Dioxus 0.5.1](#dioxus)                        |[2024/04/30](https://dioxuslabs.com/)
+      |           |[Dioxus 0.5.1](#dioxuscross-platform-library)  |[2024/04/30](https://dioxuslabs.com/)
       |           |[Bevy 0.13](#game-engine)                      |[2024/03/15](https://bevyengine.org/)
 
   1. Ubuntu 22.04.4 on Windows 11


### PR DESCRIPTION
Git関連を更新する
- Git for Windows 2.45
- GitHub Desktop 3.3.14