### PR TITLE
Update: Windows Insider Build 26120.1252

### DIFF
--- a/history/Windows.md
+++ b/history/Windows.md
@@ -1,6 +1,9 @@
 - Windows Insider History
   - [Dev Channel](https://aka.ms/DevLatest)
     - for Windows 11 24H2 (Build 26xxx)
+      - Build 26120.961 (Cumulative Update) <span style="color: red;">*<<2024/06/15 updated from 26120.770>>*</span> 
+        - 右下のバージョン情報はない（今後復活する）ため、代わりに「システム > バージョン情報」で確認
+          ![Version Information](../images/Windows/20240615_Windows11_Build26120.png)
       - Build 26120.770 (Cumulative Update) <span style="color: red;">*<<2024/06/09 updated from 26120.751>>*</span> 
         - 右下のバージョン情報はない（今後復活する）ため、代わりに「システム > バージョン情報」で確認
           ![Version Information](../images/Windows/20240609_Windows11_Build26120.png)


### PR DESCRIPTION
Windows 11 を Insider Dev Channel より、Build 26120.1252 にアップデート
- Windows の履歴が更新できていなかったので、更新