### PR TITLE
Update: WSL Kernel to Linux 6.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,23 +23,6 @@
   - [Canary Channel](https://aka.ms/CanaryLatest)
 - [WSL2](https://learn.microsoft.com/ja-jp/windows/wsl/install)
   - [Ubuntu 24.04](https://www.releases.ubuntu.com/noble/) <BR />
-    1.  <span style="color: red;">*<<2024/04/26 updated from 24.04-beta>>*</span>
-
-        <details>
-        <summary>カーネルバージョン</summary>
-
-        ```
-        WSL バージョン: 2.3.11.0
-        カーネル バージョン: 6.6.36.3-1
-        WSLg バージョン: 1.0.63
-        MSRDC バージョン: 1.2.5326
-        Direct3D バージョン: 1.611.1-81528511
-        DXCore バージョン: 10.0.26100.1-240331-1435.ge-release
-        Windows バージョン: 10.0.26120.1252
-        ```
-        </details>
-
-    1.  <span style="color: red;">*<<2024/05/27 updated from 22.04.3>>*</span>
     <details>
     <summary>ディストリビューション・バージョン情報</summary>
 
@@ -59,6 +42,39 @@
     LOGO=ubuntu-logo
     ```
     </details>
+
+    1.  IdeaPad <span style="color: red;">*<<2024/04/26 updated from 24.04-beta>>*</span>
+
+        <details>
+        <summary>カーネルバージョン</summary>
+
+        ```
+        WSL バージョン: 2.3.11.0
+        カーネル バージョン: 6.6.36.3-1
+        WSLg バージョン: 1.0.63
+        MSRDC バージョン: 1.2.5326
+        Direct3D バージョン: 1.611.1-81528511
+        DXCore バージョン: 10.0.26100.1-240331-1435.ge-release
+        Windows バージョン: 10.0.26120.1252
+        ```
+        </details>
+
+    1.  Mini-S12 <span style="color: red;">*<<2024/05/27 updated from 22.04.3>>*</span>
+
+        <details>
+        <summary>カーネルバージョン</summary>
+
+        ```
+        WSL バージョン: 2.2.4.0
+        カーネル バージョン: 5.15.153.1-2
+        WSLg バージョン: 1.0.61
+        MSRDC バージョン: 1.2.5326
+        Direct3D バージョン: 1.611.1-81528511
+        DXCore バージョン: 10.0.26091.1-240325-1447.ge-release
+        Windows バージョン: 10.0.22631.3880
+        ```
+        </details>
+
   - [履歴](./history/Wsl.md)
 - [Chrome OS Flex](https://chromereleases.googleblog.com/search/label/ChromeOS%20Flex)
   - バージョン 126.0.6478.132  <span style="color: red;">*<<2024/06/28 updated from 125.0.6422.197>>*</span>

--- a/README.md
+++ b/README.md
@@ -24,6 +24,21 @@
 - [WSL2](https://learn.microsoft.com/ja-jp/windows/wsl/install)
   - [Ubuntu 24.04](https://www.releases.ubuntu.com/noble/) <BR />
     1.  <span style="color: red;">*<<2024/04/26 updated from 24.04-beta>>*</span>
+
+        <details>
+        <summary>カーネルバージョン</summary>
+
+        ```
+        WSL バージョン: 2.3.11.0
+        カーネル バージョン: 6.6.36.3-1
+        WSLg バージョン: 1.0.63
+        MSRDC バージョン: 1.2.5326
+        Direct3D バージョン: 1.611.1-81528511
+        DXCore バージョン: 10.0.26100.1-240331-1435.ge-release
+        Windows バージョン: 10.0.26120.1252
+        ```
+        </details>
+
     1.  <span style="color: red;">*<<2024/05/27 updated from 22.04.3>>*</span>
     <details>
     <summary>ディストリビューション・バージョン情報</summary>


### PR DESCRIPTION
Windows Insiderを適用している環境において、WSL の Linux カーネルを Linux 6.6 相当にアップデート
合わせて、製品版における WSL の Linux カーネルの情報を追記