### PR TITLE
Update: Status of Rust on Exercism

### DIFF
--- a/knowhow/Exercism.md
+++ b/knowhow/Exercism.md
@@ -84,12 +84,12 @@
     |rna-transcription     |<span style="color: red;">*finished*</span>
     |run-length-encoding   |<span style="color: red;">*finished*</span>
     |saddle-points         |<span style="color: red;">*finished*</span>
-    |say                   |<span style="color: red;">*finished*</span>
+    |say                   |<span style="color: red;">*finished*</span><br /> but failed on exercism, and requested review
     |scrabble-score        |<span style="color: red;">*finished*</span>
-    |sieve                 |**2024/07/26**  <span style="color: red;">*finished*</span>
-    |simple-linked-list
+    |sieve                 |<span style="color: red;">*finished*</span>
+    |simple-linked-list    |<span style="color: yellow;">*4 tests / 9 tests passed*</span>
     |space-age             |<span style="color: red;">*finished*</span>
-    |spiral-matrix
+    |spiral-matrix         |**2024/07/31**  <span style="color: red;">*finished*</span>
     |sublist               |<span style="color: red;">*finished*</span>
     |tournament
     |triangle


### PR DESCRIPTION
Rustプログラミングスキルの向上を図るべく、Exercismで提示された問題を解くという取組をいったん終了。
→2024/7/31 時点の進捗を公開する