### PR TITLE
Fix: Tauri 2.0 RC.0

### DIFF
--- a/knowhow/Rust.md
+++ b/knowhow/Rust.md
@@ -348,7 +348,10 @@
   - Document
     - [SplashScreen](#Splashscreen)
   - V2.0
-    - V2.0 RC
+    - [V2.0 RC](https://v2.tauri.app/blog/tauri-2-0-0-release-candidate/)
+      ```
+      bun create tauri-app --rc
+      ```
       - Failed to run custom build on Ubuntu 24.04 as follows:
 
         ```
@@ -370,6 +373,7 @@
           cargo:rerun-if-changed=capabilities
           Permission path:default not found, expected one of core:app:default, ...
         ```
+        -> Fixed (capabilitiesの記述変更を取り込むことで解決)
     - V2.0 Beta
       ```
       yarn create tauri-app --beta


### PR DESCRIPTION
Rust の UI Framework である Tauri 2.0 を RC.0 に更新
- Ubuntu 24.04 では、ビルドエラーが発生
  - capabilitiesの記述変更を取り込むことで解決
