### PR TITLE
Update: Tauri 2.0 RC.2

### DIFF
--- a/knowhow/Rust.md
+++ b/knowhow/Rust.md
@@ -18,8 +18,8 @@
       |-----------|-----------------------------------------------|----------
       |Mini-S12   |[Rust 1.80](#rust-1)                           |[2024/07/27](https://www.rust-lang.org/)  
       |           |[RustRover 2024.2 EAP 3](#rustrover)           |[2024/08/09](https://www.jetbrains.com/rust/)
-      |           |[Tauri 2.0.0-rc.0](#tauridesktop-framework)    |[2024/08/03](https://beta.tauri.app/)
-      |           |Bun 1.1.21                                     |[2024/08/03](https://bun.sh/)
+      |           |[Tauri 2.0.0-rc.2](#tauridesktop-framework)    |[2024/08/10](https://beta.tauri.app/)
+      |           |Bun 1.1.22                                     |[2024/08/10](https://bun.sh/)
       |           |[Slint 1.7.1](#slint)                          |[2024/07/27](https://slint.dev/)
       |           |[Dioxus 0.5.1](#dioxuscross-platform-library)  |[2024/04/30](https://dioxuslabs.com/)
       |           |[Bevy 0.14](#game-engine)                      |[2024/07/27](https://bevyengine.org/)
@@ -28,10 +28,10 @@
       |端末       |環境／FW              |最終更新
       |-----------|---------------------|----------
       |Mini-S12   |Rust 1.80            |2024/07/27
-      |           |Tauri 2.0.0-rc.0     |2024/08/03
+      |           |Tauri 2.0.0-rc.2     |2024/08/10
       |           |React 18.3.1         |2024/05/04
-      |           |Vite 5.3.5           |2024/08/03
-      |           |Bun 1.1.21           |2024/08/03
+      |           |Vite 5.4.0           |2024/08/10
+      |           |Bun 1.1.22           |2024/08/10
       |           |Bevy 0.10.1          |2023/04/30
       |           |wasmtime 20.0.1      |[2024/05/06](https://wasmtime.dev/)
 


### PR DESCRIPTION
Rust の UI Framework である Tauri 2.0 を RC.2 に更新