### PR TITLE
Add: git Knowhow on Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@
     - [コマンドラインデベロッパツールのインストール](https://tracpath.com/bootcamp/git-install-to-mac.html)
       ![CommandLineDeveloperTools](./images/Mac/20240813_CommandLineDeveloperTools.png)
   - gitを最新化するには、[homebrew](https://brew.sh)を使って、gitをインストールする
+  - gitには、PAT(Personal Access Token)を使ってPushする
+    -> [アクセストークンがないとGitHubでpushができない](https://qiita.com/masa_code/items/bb935c499f20d0fae7b0)
 - WSL
   - WSLバージョンを確認する
     ```


### PR DESCRIPTION
Mac で Git に Push できない場合のノウハウを追加
- Personal Access Tokenを生成して、登録する手順を再確認