### PR TITLE
Fix: Change the notation of re-skilling environment

### DIFF
--- a/knowhow/Flutter.md
+++ b/knowhow/Flutter.md
@@ -24,7 +24,7 @@
     -  Startup namer
   - flutter doctor -v
     <details>
-    <summary>Mini-S12</summary>
+    <summary>Windows</summary>
 
     ```
     [✓] Flutter (Channel stable, 3.24.4, on Microsoft Windows [Version 10.0.22631.4391], locale ja-JP)

--- a/knowhow/Kotlin.md
+++ b/knowhow/Kotlin.md
@@ -13,7 +13,7 @@
   |InsiderDev |[IntelliJ IDEA 2024.2.4](#intellij-idea)                              |[2024/10/26](https://www.jetbrains.com/ja-jp/idea/)
   |           |- Kotlin 2.0.20                                                       |[2024/09/27](https://kotlinlang.org/docs/home.html)
   |           |Amazon Coretto 22.0.1                                                 |2024/05/04
-  |Mini-S12   |[Android Studio Ladybug 2024.2.1 Patch 2](#android-studio)            |[2024/11/02](https://developer.android.com/studio)
+  |Windows    |[Android Studio Ladybug 2024.2.1 Patch 2](#android-studio)            |[2024/11/02](https://developer.android.com/studio)
   |           |- Kotlin 2.0.21                                                       |[2024/10/19](https://kotlinlang.org/docs/home.html)
   |           |- Android SDK Command-line Tools v.16                                 |2024/09/04
   |           |- Android Emulator v.35.2.10                                          |2024/10/07


### PR DESCRIPTION
リスキリング環境についての表記見直し(#324)が不完全であったので、修正漏れを改善する