### PR TITLE
Fix top page display and update deployment configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@
 | ホスティング | GitHub Pages |
 | CI/CD | GitHub Actions (`.github/workflows/deploy.yml`) |
 
+## デプロイ設定
+
+GitHub Pages で Astro サイトを正しく表示するには、リポジトリの設定で **GitHub Actions** をソースとして選択する必要があります。
+
+1. GitHub リポジトリの **Settings** タブを開く
+2. 左サイドバーの **Pages** をクリック
+3. **Build and deployment** > **Source** で **GitHub Actions** を選択
+
+※ 「Deploy from a branch」が選択されていると、Astro のビルド結果ではなく `README.md` が表示されてしまいます。
+
 ## ディレクトリ構成
 
 ```

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -12,6 +12,10 @@ export default defineConfig({
         targets: [
           { src: 'images', dest: '.' },
           { src: 'captures', dest: '.' },
+          { src: 'design', dest: '.' },
+          { src: 'docs', dest: '.' },
+          { src: 'history', dest: '.' },
+          { src: 'sub', dest: '.' },
         ],
       }),
     ],


### PR DESCRIPTION
The site `https://tatsukiyoshi.github.io/` was displaying the repository's `README.md` instead of the Astro-built site. This was likely due to the GitHub Pages settings being configured to "Deploy from a branch" (serving the root) instead of using "GitHub Actions" to serve the Astro build output from `dist/`.

I have updated the `README.md` to guide the user to change the GitHub Pages source to **GitHub Actions**. Additionally, I've added a `.nojekyll` file and updated the Astro configuration to ensure all static assets (like PDFs and images stored in root directories) are correctly copied to the build output.

**Action Required by User:**
1. Go to the repository **Settings** on GitHub.
2. Select **Pages** from the left sidebar.
3. Under **Build and deployment** > **Source**, change the selection to **GitHub Actions**.
4. Once changed, the next push or manual workflow dispatch will correctly deploy the Astro site to the top page.

Fixes #770

---
*PR created automatically by Jules for task [9195933639823685583](https://jules.google.com/task/9195933639823685583) started by @Tatsukiyoshi*